### PR TITLE
tag cloud style in css style sheet

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1605,7 +1605,7 @@
 
   /* @end */
 }
-/* == Microformats == */
+/* == tagcloud == */
 .hTagcloud {
     margin-top: 2em;
   }
@@ -1659,19 +1659,19 @@
   .popular a, .popular a:visited,
   .v-popular a, .v-popular a:visited,
   .vv-popular a, .vv-popular a:visited {
-    color: #4169E1;
+    color: #3e8bff;
   }
 
   .vvv-popular a, .vvv-popular a:visited,
   .vvvv-popular a, .vvvv-popular a:visited {
-    color: #0000FF;
+    color: #0080FF;
   }
 
   .vvvvv-popular a, .vvvvv-popular a:visited,
   .vvvvvv-popular a, .vvvvvv-popular a:visited,
   .vvvvvvv-popular a, .vvvvvvv-popular a:visited,
   .vvvvvvvv-popular a, .vvvvvvvv-popular a:visited {
-    color: #0000CD;
+    color: #0174DF;
   }
 
   /* @end */

--- a/css/style.css
+++ b/css/style.css
@@ -926,6 +926,56 @@
   .browse .records {
     margin: 0 -21px;
   }
+  /* == tagcloud == */
+.hTagcloud {
+    margin-top: 2em;
+  }
+  .hTagcloud ul {
+    list-style: none;
+    margin-left: 0;
+    padding-left: 0;
+    line-height: 2em;
+  }
+  .hTagcloud li {
+    display: inline;
+    margin-right: 8px;
+  }
+
+  .popular {
+    font-size: 100%;
+  }
+
+  .v-popular {
+    font-size: 140%;
+  }
+
+  .vv-popular {
+    font-size: 180%;
+  }
+
+  .vvv-popular {
+    font-size: 220%;
+  }
+
+  .vvvv-popular {
+    font-size: 260%;
+  }
+
+  .vvvvv-popular {
+    font-size: 300%;
+  }
+
+  .vvvvvv-popular {
+    font-size: 320%;
+  }
+
+  .vvvvvvv-popular {
+    font-size: 340%;
+  }
+
+  .vvvvvvvv-popular {
+    font-size: 360%;
+  }
 
   /* @end */
   /* @group ----- Collections/Browse and Exhibits/Browse----- */
@@ -1605,73 +1655,6 @@
 
   /* @end */
 }
-/* == tagcloud == */
-.hTagcloud {
-    margin-top: 2em;
-  }
-  .hTagcloud ul {
-    list-style: none;
-    margin-left: 0;
-    padding-left: 0;
-    line-height: 1.8em;
-  }
-  .hTagcloud li {
-    display: inline;
-    margin-right: 8px;
-  }
 
-  .popular {
-    font-size: 100%;
-  }
-
-  .v-popular {
-    font-size: 140%;
-  }
-
-  .vv-popular {
-    font-size: 180%;
-  }
-
-  .vvv-popular {
-    font-size: 220%;
-  }
-
-  .vvvv-popular {
-    font-size: 260%;
-  }
-
-  .vvvvv-popular {
-    font-size: 300%;
-  }
-
-  .vvvvvv-popular {
-    font-size: 320%;
-  }
-
-  .vvvvvvv-popular {
-    font-size: 340%;
-  }
-
-  .vvvvvvvv-popular {
-    font-size: 360%;
-  }
-
-  .popular a, .popular a:visited,
-  .v-popular a, .v-popular a:visited,
-  .vv-popular a, .vv-popular a:visited {
-    color: #3e8bff;
-  }
-
-  .vvv-popular a, .vvv-popular a:visited,
-  .vvvv-popular a, .vvvv-popular a:visited {
-    color: #0080FF;
-  }
-
-  .vvvvv-popular a, .vvvvv-popular a:visited,
-  .vvvvvv-popular a, .vvvvvv-popular a:visited,
-  .vvvvvvv-popular a, .vvvvvvv-popular a:visited,
-  .vvvvvvvv-popular a, .vvvvvvvv-popular a:visited {
-    color: #0174DF;
-  }
 
   /* @end */


### PR DESCRIPTION
copied the tag cloud style from Berlin theme and included it in the Big picture theme which was lacking it initially. Adjusted the line height so hat no overlaps between words occur. The tag cloud group is included in the Items/Browse group. 